### PR TITLE
Fix bug where the copied image cannot be read externally

### DIFF
--- a/rowsSharp/Domain/Clipboard.cs
+++ b/rowsSharp/Domain/Clipboard.cs
@@ -1,16 +1,17 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Windows;
+using System.Windows.Media.Imaging;
 
 namespace RowsSharp.Domain;
 
 public static class ClipboardHelper
 {
-    public static void SetClipboardFile(string path)
+    public static void SetClipboardImage(string path)
     {
-        StringCollection list = new() { path };
+        Uri uri = new(path);
+        BitmapImage image = new(uri);
 
-        Clipboard.SetFileDropList(list);
+        Clipboard.SetImage(image);
     }
 
     public static string[,] SplitTo2DArray()

--- a/rowsSharp/ViewModel/EditorViewModel.cs
+++ b/rowsSharp/ViewModel/EditorViewModel.cs
@@ -178,7 +178,7 @@ public class EditorViewModel : NotifyPropertyChanged
     );
 
     public DelegateCommand CopyPreview => new(
-        () => ClipboardHelper.SetClipboardFile(Preview),
+        () => ClipboardHelper.SetClipboardImage(Preview),
         () => File.Exists(Preview)
     );
 


### PR DESCRIPTION
This is due to 3rd-party software not supporting the DropFileList.

Instead read the image into memory and then to the clipboard.