### PR TITLE
New Configuration: Show Welcome on Startup

### DIFF
--- a/rowsSharp/Model/CommonModel.cs
+++ b/rowsSharp/Model/CommonModel.cs
@@ -17,12 +17,12 @@ public class CommonModel
     /// <summary>
     /// User settings. Currently read from a JSON file.
     /// </summary>
-    public Preferences Preferences { get; }
+    public Preferences Preferences { get; internal set; }
 
     /// <summary>
     /// A WPF-friendly representation of the CSV file.
     /// </summary>
-    public ObservableTable<string> Table { get; }
+    public ObservableTable<string> Table { get; internal set; }
 
     // Constructors
     public CommonModel()

--- a/rowsSharp/Model/Preferences/UserInterface.cs
+++ b/rowsSharp/Model/Preferences/UserInterface.cs
@@ -29,4 +29,10 @@ public class UserInterface
     /// Whether user-friendly text is displayed upon hovering an element, especially a button.
     /// </summary>
     public bool IsToolTipEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Whether to show the home screen (new file, open file, preferences) upon starting RowsSharp.
+    /// Useful for users who don't intend to open the same file every time.
+    /// </summary>
+    public bool ShowWelcomeOnStartup { get; init; }
 }

--- a/rowsSharp/Model/Preferences/UserInterface.cs
+++ b/rowsSharp/Model/Preferences/UserInterface.cs
@@ -34,5 +34,5 @@ public class UserInterface
     /// Whether to show the home screen (new file, open file, preferences) upon starting RowsSharp.
     /// Useful for users who don't intend to open the same file every time.
     /// </summary>
-    public bool ShowWelcomeOnStartup { get; init; }
+    public bool ShowWelcomeOnStartup { get; set; }
 }

--- a/rowsSharp/Userdata/Configurations/Configuration.json
+++ b/rowsSharp/Userdata/Configurations/Configuration.json
@@ -8,9 +8,11 @@
         "WindowWidth": 1400,
         "WindowHeight": 600,
 
-        "ThemePath": "$baseDir/Configurations/Themes/Light.xaml",
+        "ThemePath": "$baseDir/Configurations/Themes/Bleach.xaml",
 
-        "IsToolTipEnabled": true
+        "IsToolTipEnabled": true,
+
+        "ShowWelcomeOnStartup": false
     },
 
     "Filter": {

--- a/rowsSharp/Userdata/Configurations/Configuration.json
+++ b/rowsSharp/Userdata/Configurations/Configuration.json
@@ -8,7 +8,7 @@
         "WindowWidth": 1400,
         "WindowHeight": 600,
 
-        "ThemePath": "$baseDir/Configurations/Themes/Bleach.xaml",
+        "ThemePath": "$baseDir/Configurations/Themes/Light.xaml",
 
         "IsToolTipEnabled": true,
 

--- a/rowsSharp/View/Editor.xaml
+++ b/rowsSharp/View/Editor.xaml
@@ -129,6 +129,7 @@
                 </Button.RenderTransform>
             </Button>
             <Rectangle/>
+            <Button DockPanel.Dock="Right" Margin="0,0,8,0" Command="{Binding OpenHome, Mode=OneTime}" Content="&#xe88a;" ToolTip="Home"/>
             <Button DockPanel.Dock="Right" Margin="0,0,8,0" Command="{Binding OpenPreferences, Mode=OneTime}" Content="&#xe8b8;" ToolTip="Preferences"/>
             <Rectangle DockPanel.Dock="Right"/>
 
@@ -329,7 +330,7 @@
                                         <Condition Binding="{Binding Table.Headers.Count, Mode=OneWay}" Value="0"/>
                                     </MultiDataTrigger.Conditions>
                                     <MultiDataTrigger.Setters>
-                                        <Setter Property="Text" Value="Empty File"/>
+                                        <Setter Property="Text" Value="Insert a row and a column using the top toolbar"/>
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
                             </Style.Triggers>

--- a/rowsSharp/View/MainWindow.xaml.cs
+++ b/rowsSharp/View/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using RowsSharp.Domain;
-﻿using RowsSharp.ViewModel;
+using RowsSharp.ViewModel;
 using System.Windows;
 
 namespace RowsSharp.View;
@@ -11,7 +11,10 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
-        DataContext = new CommonViewModel();
+        CommonViewModel viewModel = new();
+        viewModel.InitializeAsync();
+        DataContext = viewModel;
+
         ResourceDictionary theme = PreferencesReader.GetTheme(viewModel.Preferences.UserInterface.ThemePath);
         Application.Current.Resources.MergedDictionaries.Add(theme);
 

--- a/rowsSharp/View/MainWindow.xaml.cs
+++ b/rowsSharp/View/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+﻿using RowsSharp.Domain;
 ﻿using RowsSharp.ViewModel;
 using System.Windows;
 
@@ -11,6 +12,9 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         DataContext = new CommonViewModel();
+        ResourceDictionary theme = PreferencesReader.GetTheme(viewModel.Preferences.UserInterface.ThemePath);
+        Application.Current.Resources.MergedDictionaries.Add(theme);
+
         InitializeComponent();
         App.Logger.Info("Okay, it's happening! Everybody stay calm!");
     }

--- a/rowsSharp/ViewModel/CommonViewModel.cs
+++ b/rowsSharp/ViewModel/CommonViewModel.cs
@@ -71,17 +71,29 @@ public class CommonViewModel : NotifyPropertyChanged
     private const string ConfigurationPath =
         "./Userdata/Configurations/Configuration.json";
 
-    public CommonViewModel(Preferences? preferences = null)
+    public CommonViewModel()
     {
-        preferences ??= PreferencesReader.Import(ConfigurationPath);
+        var preferences = PreferencesReader.Import(ConfigurationPath);
+
         ResourceDictionary theme = PreferencesReader.GetTheme(preferences.UserInterface.ThemePath);
         Application.Current.Resources.MergedDictionaries.Add(theme);
 
-        // Don't block the UI thread
-        Task.Run(() => CreateModel(preferences));
+        if (preferences.UserInterface.ShowWelcomeOnStartup)
+        {
+            CurrentSection = Section.Welcome;
+            return;
+        }
+
+        InitializeAsync(preferences);
     }
 
-    private void CreateModel(Preferences preferences)
+    public async void InitializeAsync(Preferences preferences)
+    {
+        // Don't block the UI thread
+        await Task.Run(() => Initialize(preferences));
+    }
+
+    private void Initialize(Preferences preferences)
     {
         var table = CsvFile.Import(preferences.Csv.Path, preferences.Csv.HasHeader);
 

--- a/rowsSharp/ViewModel/EditorViewModel.cs
+++ b/rowsSharp/ViewModel/EditorViewModel.cs
@@ -356,4 +356,14 @@ public class EditorViewModel : NotifyPropertyChanged
     public DelegateCommand OpenPreferences => new(() =>
         commonViewModel.CurrentSection = Section.Settings
     );
+
+    public DelegateCommand OpenHome => new(() =>
+    {
+        CancelEventArgs e = new();
+        commonViewModel.Exit.Execute(e);
+
+        if (e.Cancel) { return; }
+
+        commonViewModel.CurrentSection = Section.Welcome;
+    });
 }

--- a/rowsSharp/ViewModel/WelcomeViewModel.cs
+++ b/rowsSharp/ViewModel/WelcomeViewModel.cs
@@ -16,7 +16,7 @@ public class WelcomeViewModel
         string path = FileDialogHelper.RequestReadPath();
 
         CommonViewModel.Preferences.Csv.Path = path;
-        CommonViewModel = new(CommonViewModel.Preferences);
+        CommonViewModel.InitializeAsync(CommonViewModel.Preferences);
     });
 
     public DelegateCommand NewFile => new(() => 

--- a/rowsSharp/ViewModel/WelcomeViewModel.cs
+++ b/rowsSharp/ViewModel/WelcomeViewModel.cs
@@ -16,7 +16,8 @@ public class WelcomeViewModel
         string path = FileDialogHelper.RequestReadPath();
 
         CommonViewModel.Preferences.Csv.Path = path;
-        CommonViewModel.InitializeAsync(CommonViewModel.Preferences);
+        CommonViewModel.Preferences.UserInterface.ShowWelcomeOnStartup = false;
+        CommonViewModel.InitializeAsync();
     });
 
     public DelegateCommand NewFile => new(() => 

--- a/rowsSharp/rowsSharp.csproj
+++ b/rowsSharp/rowsSharp.csproj
@@ -10,6 +10,7 @@
 	<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 	<SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
 	<GenerateDocumentationFile>False</GenerateDocumentationFile>
+	<StartupObject></StartupObject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
New `UserInterface.ShowWelcomeOnStartup` Boolean option.

When enabled, RowsSharp will show the welcome screen, prompting the user to create a new file or open an existing one, regardless whether or not a file path is defined in `Csv.Path`.

Useful for users who open different files frequently.