### PR TITLE
Full customizability on column/row dimension constraints

### DIFF
--- a/rowsSharp/Model/Preferences/ColumnStyle.cs
+++ b/rowsSharp/Model/Preferences/ColumnStyle.cs
@@ -32,12 +32,12 @@ public class ColumnStyle
     /// <summary>
     /// The minimum width of the column
     /// </summary>
-    public double MinWidth { get; set; } = 32;
+    public double MinWidth { get; set; }
 
     /// <summary>
     /// The default maximum width of the column
     /// </summary>
-    public double MaxWidth { get; set; } = double.PositiveInfinity;
+    public double MaxWidth { get; set; }
 
     /// <summary>
     /// The template of the column.

--- a/rowsSharp/Model/Preferences/Editor.cs
+++ b/rowsSharp/Model/Preferences/Editor.cs
@@ -47,12 +47,33 @@ public class Editor
     public double DefaultRowHeight { get; set; } = 33;
 
     /// <summary>
+    /// Fallback minimum height of a row.
+    /// </summary>
+    public double DefaultMinRowHeight { get; set; }
+
+    /// <summary>
     /// Fallback width of a column.
     /// </summary>
     /// <remarks>
     /// ColumnStyles can override this value on a column-to-column basis.
     /// </remarks>
     public double DefaultColumnWidth { get; set; } = 50;
+
+    /// <summary>
+    /// Fallback minimum width of a column.
+    /// </summary>
+    /// <remarks>
+    /// ColumnStyles can override this value on a column-to-column basis.
+    /// </remarks>
+    public double DefaultMinColumnWidth { get; set; } = 25;
+
+    /// <summary>
+    /// Fallback maximum width of a column.
+    /// </summary>
+    /// <remarks>
+    /// ColumnStyles can override this value on a column-to-column basis.
+    /// </remarks>
+    public double DefaultMaxColumnWidth { get; set; }
 
     /// <summary>
     /// Whether scrolling only occurs after the scrollbar has finished moving.

--- a/rowsSharp/Userdata/Configurations/Configuration.json
+++ b/rowsSharp/Userdata/Configurations/Configuration.json
@@ -29,7 +29,10 @@
     "IsAutosaveEnabled": true,
     "AutosaveInterval": 60000,
     "FrozenColumn": 0,
-    "DefaultRowHeight": 33,
+    "DefaultMinRowHeight": 28,
+    "DefaultRowHeight": 34,
+    "DefaultMinColumnWidth": 16,
+    "DefaultMaxColumnWidth": 256,
     "DefaultColumnWidth": 128,
     "IsDeferredScrollingEnabled": false,
     "ColumnStyles": [

--- a/rowsSharp/View/DataGridColumn/DataGridColumnFactory.cs
+++ b/rowsSharp/View/DataGridColumn/DataGridColumnFactory.cs
@@ -44,8 +44,8 @@ internal static class DataGridColumnFactory
         column.Binding = binding;
         column.Header = style.Column;
         column.Width = style.Width > 0 ? style.Width : column.Width;
-        column.MinWidth = style.MinWidth;
-        column.MaxWidth = style.MaxWidth;
+        if (style.MinWidth > 0) { column.MinWidth = style.MinWidth; }
+        if (style.MaxWidth > 0) { column.MaxWidth = style.MaxWidth; }
         column.CellStyle = ColumnStyleHelper.GetConditionalFormatting(style.ConditionalFormatting);
 
         return column;

--- a/rowsSharp/View/Editor.xaml
+++ b/rowsSharp/View/Editor.xaml
@@ -210,12 +210,19 @@
                     VerticalGridLinesBrush="{StaticResource Rows.DataGrid.Grid.Vertical}"
                     HorizontalGridLinesBrush="{StaticResource Rows.DataGrid.Grid.Horizontal}"
                     ScrollViewer.IsDeferredScrollingEnabled="{Binding Preferences.Editor.IsDeferredScrollingEnabled, Mode=OneWay}"
+                    MinColumnWidth="{Binding Preferences.Editor.DefaultMinColumnWidth, Mode=OneTime}"
+                    MaxColumnWidth="{Binding Preferences.Editor.DefaultMaxColumnWidth, Mode=OneTime}"
+                    MinRowHeight="{Binding Preferences.Editor.DefaultMinRowHeight, Mode=OneTime}"
                     ColumnWidth="{Binding Preferences.Editor.DefaultColumnWidth, Mode=OneTime}" RowHeaderWidth="8"
                     RowHeight="{Binding Preferences.Editor.DefaultRowHeight, Mode=OneTime}"                      
                     CanUserAddRows="False" CanUserDeleteRows="False" IsReadOnly="{Binding Preferences.Editor.CanEdit, Converter={StaticResource InvertBooleanConverter}, Mode=OneWay}"
                     SelectionMode="Extended" SelectionUnit="CellOrRowHeader"
+                    FrozenColumnCount="{Binding Preferences.Editor.FrozenColumn, Mode=OneTime}"
                     CanUserReorderColumns="{Binding Preferences.Editor.CanEdit, Mode=OneWay}"
-				    EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.ScrollUnit="Pixel">                
+				    EnableColumnVirtualization="True" EnableRowVirtualization="True"
+                    VirtualizingPanel.VirtualizationMode="Recycling"
+                    VirtualizingPanel.IsVirtualizing="True"
+                    VirtualizingPanel.ScrollUnit="Pixel">                
                 <DataGrid.ContextMenu>
                     <ContextMenu DataContext="{Binding PlacementTarget, RelativeSource={x:Static RelativeSource.Self}}">
                         <MenuItem Command="{Binding DataContext.CopyPreview, Mode=OneTime}" Header="Copy image" InputGestureText="Ctrl+Shift+C"/>


### PR DESCRIPTION
Introducing three new options
- MinRowHeight
- MinColumnWidth
- MaxColumnWidth

to `Preferences.Editor`.

These settings are global and will affect all rows and columns. The minimum and maximum column widths can be overridden individually by defining a `ColumnStyle` for the columns in question.
